### PR TITLE
16 weighted power stats logic

### DIFF
--- a/app/graphql/types/character_type.rb
+++ b/app/graphql/types/character_type.rb
@@ -22,6 +22,7 @@ module Types
     field :hair_color, String
     field :group_affiliation, String
     field :image, String
+    field :power_stats_weighted_average, Float
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,6 +4,8 @@ module Types
   class QueryType < Types::BaseObject
 
     field :characters, [Types::CharacterType], null: false
+    field :get_characters, [Types::CharacterType], null: false
+    field :character, [Types::CharacterType], null: false
 
     field :node, Types::NodeType, null: true, description: "Fetches an object given its ID." do
       argument :id, ID, required: true, description: "ID of the object."

--- a/db/migrate/20231016201538_add_power_stats_weighted_average_to_characters.rb
+++ b/db/migrate/20231016201538_add_power_stats_weighted_average_to_characters.rb
@@ -1,0 +1,5 @@
+class AddPowerStatsWeightedAverageToCharacters < ActiveRecord::Migration[7.0]
+  def change
+    add_column :characters, :power_stats_weighted_average, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_11_210231) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_16_201538) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_11_210231) do
     t.string "hair_color"
     t.string "group_affiliation"
     t.string "image"
+    t.float "power_stats_weighted_average"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/tasks/superhero_api.rake
+++ b/lib/tasks/superhero_api.rake
@@ -79,6 +79,17 @@ namespace :superhero do
           character.hair_color = data['appearance']['hair-color']
           character.group_affiliation = data['connections']['group-affiliation']
           character.image = data['image']['url']
+
+          intelligence_weight = (data['powerstats']['intelligence'].to_f*0.10)
+          speed_weight = (data['powerstats']['speed'].to_f*0.20)
+          strength_weight = (data['powerstats']['strength'].to_f*0.15)
+          power_weight = (data['powerstats']['power'].to_f*0.15)
+          durability_weight = (data['powerstats']['durability'].to_f*0.20)
+          combat_weight = (data['powerstats']['combat'].to_f*0.20)
+
+          weighted_average = intelligence_weight + strength_weight + speed_weight+ durability_weight + power_weight + combat_weight
+          character.power_stats_weighted_average = weighted_average
+      
           character.save
           id += 1
         else

--- a/lib/tasks/superhero_api.rake
+++ b/lib/tasks/superhero_api.rake
@@ -88,7 +88,7 @@ namespace :superhero do
           combat_weight = (data['powerstats']['combat'].to_f*0.20)
 
           weighted_average = intelligence_weight + strength_weight + speed_weight+ durability_weight + power_weight + combat_weight
-          character.power_stats_weighted_average = weighted_average
+          character.power_stats_weighted_average = weighted_average.floor
       
           character.save
           id += 1


### PR DESCRIPTION
## Description
Adds power_stats_weighted_average to the schema and to the superhero_api.rake file.  Adds and rounds the total number of all power stats to one number.

## Related Issue
Closes issue #16 

## Checklist
- [ x] I have reviewed the code changes.
- [x ] I have tested this code.
- [x ] I have requested an update to the documentation.
- [x ] I have checked for and resolved any merge conflicts.
- [ x] I have assigned reviewers for this PR.
