### PR TITLE
fix: origins url

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module FffBe
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins 'localhost:3000' # Add your React development server's address here
+        origins 'https://fff-fe.vercel.app' # Your React development server's address
         resource '*', headers: :any, methods: [:get, :post, :put, :patch, :delete, :options, :head]
       end
     end


### PR DESCRIPTION
## Description
this PR fixes the RackCORS config to recognize https://fff-fe.vercel.app as our FE server.

## Related Issue
[Link to any related issue(s) that this PR addresses, e.g., "Closes #123"]

## Checklist
- [x] I have reviewed the code changes.
- [x] I have tested this code.
- [x] I have requested an update to the documentation.
- [x] I have checked for and resolved any merge conflicts.
- [x] I have assigned reviewers for this PR.
